### PR TITLE
Creating new option to select how Duf induces file extensions for HttpDownloads

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,6 +2,7 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
+use JeanSouzaK\Duf\Download\DownloadOptions;
 use JeanSouzaK\Duf\Duff;
 use JeanSouzaK\Duf\Prepare\WebResource;
 use JeanSouzaK\Duf\Filter\WebFileSizeFilter;
@@ -14,14 +15,14 @@ use JeanSouzaK\Duf\Filter\HeaderFilterable;
 use JeanSouzaK\Duf\Prepare\LocalResource;
 
 $duf = Duff::getInstance(Duff::GOOGLE_CLOUD_STORAGE, [
-    'project_id' => 'storage-test-227305',
-    'key_path' => '/home/env/storage-test-227305-8472347a39489.json'
+    'project_id' => 'mybucket-280818',
+    'key_path' => './mybucket-280818-14d6f8d296cd.json'
 ]);
 
 // - Chaining example -
 $uploadResults = $duf->prepare([
     new WebResource('teste.png', 'https://dummyimage.com/600x400/000/fff')
-])->download()->addBucket('meubucket666')->upload();
+])->download()->addBucket('dufbuckettest')->upload();
 
 
 // - Step-by-step example -
@@ -37,7 +38,7 @@ $duf->prepare([
 $duf->download();
 
 //Add google cloud storage bucket name
-$duf->addBucket('meubucket666');
+$duf->addBucket('dufbuckettest');
 
 //Upload downloaded files to bucket and get results
 $uploadResults = $duf->upload();
@@ -65,7 +66,7 @@ $duf->prepare([
 $duf->download();
 
 //Add google cloud storage bucket name
-$duf->addBucket('meubucket666');
+$duf->addBucket('dufbuckettest');
 
 //Upload downloaded files to bucket and get results
 $fileResults = $duf->upload();
@@ -73,8 +74,8 @@ $fileResults = $duf->upload();
 
 //Call Factory to get google cloud storage duffer instance
 $duf = Duff::getInstance(Duff::GOOGLE_CLOUD_STORAGE, [
-    'project_id' => 'storage-test-277005',
-    'key_path' => '/home/jean/Workspace/estudo/down-up-files/env/storage-test-277005-3334a1054345.json'
+    'project_id' => 'mybucket-280818',
+    'key_path' => './mybucket-280818-14d6f8d296cd.json'
 ]);
 
 //[WEB Filter] Configure a maximum file size to bind in a resource
@@ -101,11 +102,18 @@ $duf->prepare([
     new LocalResource('imagem', '/home/test/project/composer.json', [$localAllowedExtensionFilter]),  
 ]);
 
+//Create DownloadOptions(optional)
+$downloadOptions = new DownloadOptions();
+//Telling Duf to induce the file extension(default false)
+$downloadOptions->setInduceType(true);
+//Using file URL to induce file extension(defaul INDUCE_FROM_BOTH)
+$downloadOptions->setInduceMethod(DownloadOptions::INDUCE_FROM_URL);
+
 //Make download prepared files
-$duf->download();
+$duf->download($downloadOptions);
 
 //Add google cloud storage bucket name
-$duf->addBucket('meubucket666');
+$duf->addBucket('dufbuckettest');
 
 //Upload downloaded files to bucket and get results
 $fileResults = $duf->upload();

--- a/src/AbstractDuf.php
+++ b/src/AbstractDuf.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace JeanSouzaK\Duf;
 
@@ -63,18 +64,15 @@ abstract class AbstractDuf implements Dufable
         $this->erroredFiles = [];
     }
 
-    public function prepare(array $resources, $authorizationHeaders = [])
+    public function prepare(array $resources)
     {
         /** @var Resource $resource */
-        array_filter($resources, function ($resource) use ($authorizationHeaders) {
-            if (!(is_string($resource->getName()) && !empty($resource->getUrl()) )) {
+        array_filter($resources, function ($resource) {
+            if (!(is_string($resource->getName()) && !empty($resource->getUrl()))) {
                 throw new \InvalidArgumentException('One or more resources not contain an empty name or path');
             }
-            if($resource instanceof WebResource && !filter_var($resource->getUrl(), FILTER_VALIDATE_URL)) {
+            if ($resource instanceof WebResource && !filter_var($resource->getUrl(), FILTER_VALIDATE_URL)) {
                 throw new \InvalidArgumentException('One or more web resources contain an invalid URL');
-            }
-            if (count($authorizationHeaders) > 0) {
-                $resource->setAuthentication($authorizationHeaders);
             }
             $this->fileResources[] = $resource;
         }, ARRAY_FILTER_USE_BOTH);
@@ -94,20 +92,19 @@ abstract class AbstractDuf implements Dufable
             $file = new File();
             try {
                 $response = $fileResource->download($options);
-                if(!$response) {
+                if (!$response) {
                     $file->setStatus(File::ERROR);
                     $file->setErrorMessage('Error on download file');
-                }
-                else if($fileResource instanceof WebResource) {                    
-                    $fileResource->processHeaderFilters($response->getHeaders());
-                    $body = $response->getBody();                
+                } else if ($fileResource instanceof WebResource) {
+                    //$fileResource->processHeaderFilters($response->getHeaders());
+                    $body = $response->getBody();
                     while (!$body->eof()) {
                         $file->addBytes($body->read(1024));
                     }
                 } else {
                     $fileResource->processPathFilters(array_merge(pathinfo($fileResource->getUrl()), ['size' => filesize($fileResource->getUrl())]));
                     $file->addBytes($response);
-                }                
+                }
             } catch (\Exception $e) {
                 $file->setStatus(File::ERROR);
                 $file->setErrorMessage($e->getMessage());
@@ -131,7 +128,7 @@ abstract class AbstractDuf implements Dufable
     }
 
 
-    
+
 
     /**
      * Get $fileResources

--- a/src/Download/DownloadOptions.php
+++ b/src/Download/DownloadOptions.php
@@ -6,9 +6,14 @@ namespace JeanSouzaK\Duf\Download;
 
 class DownloadOptions
 {
+    const INDUCE_FROM_BOTH = 1;
+    const INDUCE_FROM_URL = 2;
+    const INDUCE_FROM_CONTENT_TYPE = 3;
+
     public function __construct()
     {
         $this->induceType = false;
+        $this->induceMethod = self::INDUCE_FROM_BOTH;
     }
     /**
      * Duf tries read content / mime type from file headers and put (concat) with file name
@@ -16,6 +21,20 @@ class DownloadOptions
      * @var bool
      */
     private $induceType;
+
+    /**
+     * Duf can use file url or contentType header do induce file extensionm defaults to 
+     * 
+     * @var string
+     */
+    private $induceMethod;
+
+    /**
+     * 
+     * 
+     * @var array
+     */
+    private $authentication;
 
     /**
      * Get duf tries read content / mime type from file headers and put (concat) with file name
@@ -37,6 +56,54 @@ class DownloadOptions
     public function setInduceType(bool $induceType)
     {
         $this->induceType = $induceType;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of authentication
+     *
+     * @return  array
+     */ 
+    public function getAuthentication()
+    {
+        return $this->authentication;
+    }
+
+    /**
+     * Set the value of authentication
+     *
+     * @param  array  $authentication
+     *
+     * @return  self
+     */ 
+    public function setAuthentication(array $authentication)
+    {
+        $this->authentication = $authentication;
+
+        return $this;
+    }
+
+    /**
+     * Get duf can use file url or contentType header do induce file extensionm defaults to
+     *
+     * @return  string
+     */ 
+    public function getInduceMethod()
+    {
+        return $this->induceMethod;
+    }
+
+    /**
+     * Set duf can use file url or contentType header do induce file extensionm defaults to
+     *
+     * @param  string  $induceMethod  Duf can use file url or contentType header do induce file extensionm defaults to
+     *
+     * @return  self
+     */ 
+    public function setInduceMethod(string $induceMethod)
+    {
+        $this->induceMethod = $induceMethod;
 
         return $this;
     }

--- a/src/Download/Downloadable.php
+++ b/src/Download/Downloadable.php
@@ -7,5 +7,5 @@ use JeanSouzaK\Duf\Prepare\Resourceable;
 
 interface Downloadable
 {
-    public function download(Resourceable $resourceable);
+    public function download();
 }

--- a/src/Download/Intercepter/HttpInterceptable.php
+++ b/src/Download/Intercepter/HttpInterceptable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeanSouzaK\Duf\Download\Intercepter;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface HttpInterceptable
+{
+    public function interceptHeaderFilters(ResponseInterface $response);
+
+    public function induceFileExtension(ResponseInterface $response);
+}

--- a/src/Download/Intercepter/HttpIntercepter.php
+++ b/src/Download/Intercepter/HttpIntercepter.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeanSouzaK\Duf\Download\Intercepter;
+
+use JeanSouzaK\Duf\Download\DownloadOptions;
+use JeanSouzaK\Duf\Filter\HeaderFilterable;
+use JeanSouzaK\Duf\Prepare\WebResource;
+use Psr\Http\Message\ResponseInterface;
+
+class HttpIntercepter implements HttpInterceptable
+{
+    /**
+     * The resource from which HttpIntercepter will get informations of the file Duf downloaded to proccess
+     * filters and induce it's extension
+     *
+     * @var WebResource
+     */
+    private $webResource;
+
+    public function __construct(WebResource $webResource)
+    {
+        $this->webResource = $webResource;
+    }
+
+    public function interceptHeaderFilters(ResponseInterface $response)
+    {
+        $headers = $response->getHeaders();
+        if (count($this->webResource->getFilters()) == 0) {
+            return true;
+        }
+        $headerFilters = array_filter($this->webResource->getFilters(), function ($filter) {
+            return $filter instanceof HeaderFilterable;
+        });
+
+        /** @var HeaderFilterable $headerFilter */
+        foreach ($headerFilters as $headerFilter) {
+            $headerFilter->applyHeaderFilter($headers);
+        }
+
+        return true;
+    }
+
+    public function induceFileExtension(ResponseInterface $response)
+    {
+        $downloadOptions = $this->webResource->getDownloadOptions();
+
+        if (!$downloadOptions) {
+            return;
+        }
+
+        if (!$downloadOptions->getInduceType()) {
+            return;
+        }
+
+        switch ($downloadOptions->getInduceMethod()) {
+            case DownloadOptions::INDUCE_FROM_URL:
+                return $this->induceExtensionFromUrl($this->webResource->getUrl());
+            case DownloadOptions::INDUCE_FROM_CONTENT_TYPE:
+                return $this->induceExtensionFromContentType($response->getHeaders());
+            default:
+                if ($this->induceExtensionFromUrl($this->webResource->getUrl())) {
+                    return true;
+                }
+                return $this->induceExtensionFromContentType($response->getHeaders());
+        }
+    }
+
+    public function induceExtensionFromUrl($url)
+    {
+        $extension = pathinfo($url, PATHINFO_EXTENSION);
+        $queryParamsDelimiter = strpos($extension, "?");
+
+        if (!$extension) {
+            return false;
+        }
+
+        if (!$queryParamsDelimiter) {
+            $name = $this->webResouce->getName() . $extension;
+            $this->webResouce->setName($name);
+            return true;
+        }
+
+        $extension = substr($extension, 0, $queryParamsDelimiter);
+        $name = $this->webResouce->getName() . $extension;
+        $this->webResouce->setName($name);
+        return true;
+    }
+
+    public function induceExtensionFromContentType($headersContentType)
+    {
+        $contentTypes = $headersContentType && count($headersContentType) > 0  ? explode('/', $headersContentType[0]) : [];
+        $extensionType = count($contentTypes) > 1 ? '.' . $contentTypes[1] : '';
+        $name = $this->webResouce->getName() . $extensionType;
+        $this->webResouce->setName($name);
+    }
+}

--- a/src/Download/LocalDownload.php
+++ b/src/Download/LocalDownload.php
@@ -1,19 +1,31 @@
 <?php
+
 declare(strict_types=1);
 
 namespace JeanSouzaK\Duf\Download;
 
-use GuzzleHttp\Client;
 use JeanSouzaK\Duf\Prepare\Resourceable;
 use JeanSouzaK\Duf\Exception\FileNotFoundException;
 
 class LocalDownload implements Downloadable
 {
-    public function download(Resourceable $resource)
+    /**
+     * The resource from which LocalDownload will get informations on where to search for the file and download it
+     *
+     * @var Resourceable
+     */
+    private $resource;
+
+    public function __construct(Resourceable $resource)
     {
-        if (!file_exists($resource->getUrl())) {
-            throw new FileNotFoundException('File not found on path '.$resource->getUrl());
+        $this->resource = $resource;
+    }
+
+    public function download()
+    {
+        if (!file_exists($this->resource->getUrl())) {
+            throw new FileNotFoundException('File not found on path ' . $this->resource->getUrl());
         }
-        return file_get_contents($resource->getUrl());
+        return file_get_contents($this->resource->getUrl());
     }
 }

--- a/src/Dufable.php
+++ b/src/Dufable.php
@@ -14,7 +14,7 @@ interface Dufable
      * @param string $token
      * @return void
      */
-    public function prepare(array $resources, $token = '');
+    public function prepare(array $resources);
 
     public function download();
 

--- a/src/Prepare/LocalResource.php
+++ b/src/Prepare/LocalResource.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace JeanSouzaK\Duf\Prepare;
@@ -11,7 +12,7 @@ class LocalResource extends Resource
 {
     public function download(DownloadOptions $options = null)
     {
-        $localDownload = new LocalDownload();
+        $localDownload = new LocalDownload($this);
         $induceType = $options && $options->getInduceType() ? true : false;
         return $localDownload->download($this, $induceType);
     }
@@ -24,7 +25,7 @@ class LocalResource extends Resource
         $pathFilters = array_filter($this->filters, function ($filter) {
             return $filter instanceof PathFilterable;
         });
-            
+
         /** @var HeaderFilterable $headerFilter */
         foreach ($pathFilters as $pathFilters) {
             $pathFilters->applyPathFilters($headers);

--- a/src/Prepare/Resource.php
+++ b/src/Prepare/Resource.php
@@ -15,11 +15,6 @@ abstract class Resource implements Resourceable
     protected $url;
 
     /**
-     * @var []
-     */
-    protected $authentication;
-
-    /**
      * Defined name
      *
      * @var string
@@ -36,14 +31,12 @@ abstract class Resource implements Resourceable
 
     /**
      * @var string $url
-     * @var Authentication $authentication
      */
-    public function __construct($name, $url, $filters = [], array $authentication = [])
+    public function __construct($name, $url, $filters = [])
     {
         $this->name = $name;
         $this->url = $url;
         $this->filters = $filters;
-        $this->authentication = $authentication;
     }
 
     
@@ -114,29 +107,4 @@ abstract class Resource implements Resourceable
         return $this->name;
     }
 
-     
-
-    /**
-     * Get the value of authentication
-     *
-     * @return  []
-     */ 
-    public function getAuthentication()
-    {
-        return $this->authentication;
-    }
-
-    /**
-     * Set the value of authentication
-     *
-     * @param  []  $authentication
-     *
-     * @return  self
-     */ 
-    public function setAuthentication(array $authentication)
-    {
-        $this->authentication = $authentication;
-
-        return $this;
-    }
 }

--- a/src/Prepare/WebResource.php
+++ b/src/Prepare/WebResource.php
@@ -1,52 +1,56 @@
 <?php
+
 declare(strict_types=1);
 
 namespace JeanSouzaK\Duf\Prepare;
 
 use JeanSouzaK\Duf\Download\DownloadOptions;
 use JeanSouzaK\Duf\Download\HttpDownload;
-use JeanSouzaK\Duf\Filter\HeaderFilterable;
 
 class WebResource extends Resource
 {
 
-    public function download(DownloadOptions $options = null) 
+    public function __construct($name, $url, $filters = [], DownloadOptions $downloadOptions = null)
     {
-        $httpDownload = new HttpDownload();
-        $induceType = $options && $options->getInduceType() ? true : false;
-        return $httpDownload->download($this, $induceType);
+        parent::__construct($name, $url, $filters);
+        $this->$downloadOptions = $downloadOptions;
     }
 
-     /**
-     * Apply header filters
-     *
-     * @param array $headers
-     * @return void
-     * @throws Exception
+    /**
+     * 
+     * 
+     * @var DownloadOptions
      */
-    public function processHeaderFilters($headers)
+    private $downloadOptions;
+
+    public function download(DownloadOptions $options = null)
     {
-        if(count($this->filters) == 0) {
-            return true;
-        }        
-        $headerFilters = array_filter($this->filters, function ($filter) {
-            return $filter instanceof HeaderFilterable;
-        });
-                
-        /** @var HeaderFilterable $headerFilter */
-        foreach ($headerFilters as $headerFilter) {
-            $headerFilter->applyHeaderFilter($headers);
-        }
-
-        return true;
+        $this->downloadOptions = $this->downloadOptions ? $this->downloadOptions : $options;
+        $httpDownload = new HttpDownload($this);
+        return $httpDownload->download();
     }
 
-
-    public function induceExtensionFromContentType($headersContentType) 
-    {   
-        $contentTypes = $headersContentType && count($headersContentType) > 0  ? explode('/', $headersContentType[0]) : [];
-        $extensionType = count($contentTypes) > 1 ? '.'.$contentTypes[1] : '';
-        $this->name .= $extensionType;        
+    /**
+     * Get the value of downloadOptions
+     *
+     * @return  DownloadOptions
+     */ 
+    public function getDownloadOptions()
+    {
+        return $this->downloadOptions;
     }
 
+    /**
+     * Set the value of downloadOptions
+     *
+     * @param  DownloadOptions  $downloadOptions
+     *
+     * @return  self
+     */ 
+    public function setDownloadOptions(DownloadOptions $downloadOptions)
+    {
+        $this->downloadOptions = $downloadOptions;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Duf now can induce the extension of a file through it's URL or ContentType, default behavior is both(it first tries from the URL or then ContentType header if URL was unsuccessful).

Moving auth headers to DownloadOptions and creating Intercepter module for Http downloads.