### PR TITLE
Fixing extension filter for local file

### DIFF
--- a/src/AbstractDuf.php
+++ b/src/AbstractDuf.php
@@ -102,7 +102,11 @@ abstract class AbstractDuf implements Dufable
                         $file->addBytes($body->read(1024));
                     }
                 } else {
-                    $fileResource->processPathFilters(array_merge(pathinfo($fileResource->getUrl()), ['size' => filesize($fileResource->getUrl())]));
+                    $header = [
+                      'size' => filesize($fileResource->getUrl()),
+                      'extension' => mime_content_type($fileResource->getUrl())
+                    ];
+                    $fileResource->processPathFilters(array_merge(pathinfo($fileResource->getUrl()), $header));
                     $file->addBytes($response);
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
Stopping using the extension present in the file name, obtained through the pathinfo method, to use the real file extension, obtained through mime_content_type