### PR TITLE
limiting ternary on setResultPath

### DIFF
--- a/src/Duffer/GCSDuffer.php
+++ b/src/Duffer/GCSDuffer.php
@@ -65,7 +65,7 @@ class GCSDuffer extends AbstractDuf
                 $bucketObj = $bucket->upload($fileToUpload->getBytes(), [
                     'name' => $fileName
                 ]);
-                $fileToUpload->setResultPath(self::STORAGE_URI . $this->bucketName . '/' . $bucketObj->name() ? $bucketObj->name() : $fileName);
+                $fileToUpload->setResultPath(self::STORAGE_URI . $this->bucketName . '/' . ($bucketObj->name() ? $bucketObj->name() : $fileName));
                 $fileToUpload->setStatus(FILE::FINISHED);
             } catch (\Exception $e) {
                 $fileToUpload->setErrorMessage($e->getMessage());


### PR DESCRIPTION
I forgot to limit the ternary scope, which resulted on all URL being swapped by the file-name.
This pull-request fixes that issue.